### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+artifacts
+test/
+**/bin/
+**/obj/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:2.1 as build
+
+WORKDIR /azure-relay-bridge/src
+
+COPY src/azbridge/azbridge.csproj /azure-relay-bridge/src/azbridge/
+COPY src/Microsoft.Azure.Relay.Bridge/Microsoft.Azure.Relay.Bridge.csproj /azure-relay-bridge/src/Microsoft.Azure.Relay.Bridge/
+
+RUN dotnet restore /azure-relay-bridge/src/azbridge/azbridge.csproj
+
+COPY . /azure-relay-bridge/
+
+WORKDIR /azure-relay-bridge/src/azbridge
+RUN dotnet build azbridge.csproj
+
+
+FROM build AS publish
+WORKDIR /azure-relay-bridge/src/azbridge
+RUN dotnet publish azbridge.csproj -c Release -f netcoreapp2.1 -o /app
+
+
+FROM mcr.microsoft.com/dotnet/core/runtime:2.1
+WORKDIR /app
+COPY --from=publish /app .


### PR DESCRIPTION
Have tested building this with `docker build -t azbridge -f Dockerfile .` in the root of the repo. 

I've left out the ENTRYPOINT as it's not obvious to me how what that should default to. I've tested running the resulting image via `docker run azbridge dotnet azbridge.dll -L <rest of args omitted>`. I've also tested it in Kubernetes specifying the `command` and `args`, e.g.

```yaml
  command:
    - dotnet
  args:
    - azbridge.dll 
    - --config-file
    - /azbridge-config/config.yaml 
    - -v 
    - -x 
    - Endpoint=sb://xxx.servicebus.windows.net/;...
```