### PR TITLE
update Azure.Identity to 1.14.2 & actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -3,123 +3,129 @@ name: Main and Release CI Build
 on:
   workflow_dispatch:
   push:
-    branches: [ master, main ]
+    branches: [master, main]
   create:
     tags:
-      - 'v*.*'
+      - "v*.*"
   pull_request:
-    branches: [ master, main ]
+    branches: [master, main]
 
 jobs:
   build:
-    permissions: write-all 
+    permissions: write-all
     strategy:
-       matrix:
-         os: [ubuntu-latest, windows-latest, macos-latest]
-         include:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        include:
           - os: windows-latest
             windows: true
     runs-on: ${{ matrix.os }}
 
     steps:
-    - run: |
-        mkdir artifacts
-        mkdir artifacts/build
+      - run: |
+          mkdir artifacts
+          mkdir artifacts/build
 
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0 # Mandatory to use the extract version from tag action
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Mandatory to use the extract version from tag action
 
-    - name: Extract version from tag
-      uses: damienaicheh/extract-version-from-tag-action@v1.0.0
-      
-      
-    - name: Setup .NET SDK
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 8.0.x
-    
-    - name: Restore dependencies
-      run: dotnet restore
+      - name: Extract version from tag
+        uses: damienaicheh/extract-version-from-tag-action@v1.0.0
 
-    - name: Build Docker Image TAR file
-      run: |
-         mkdir -p artifacts/build/images 
-         DOCKER_BUILDKIT=1 docker build . --build-arg "REVISION=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}" --build-arg "VERSION=${{ env.MAJOR }}.${{ env.MINOR }}" -t azbridge:${{ env.MAJOR }}.${{ env.MINOR }} -t azbridge
-         docker save azbridge:${{ env.MAJOR }}.${{ env.MINOR }} > artifacts/build/images/azbridge-oci-image-${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}.tar
-      if: matrix.os == 'ubuntu-latest'
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
 
-    - name: Build for Windows-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=true /p:RuntimeIdentifier=win-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'windows-latest'
-    - name: Build for Windows-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'windows-latest'
-    - name: Build for Windows-x86
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-x86 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'windows-latest'
-    - name: Build for macOS-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'macos-latest'
-    - name: Build for macOS-arm64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'macos-latest'
-    - name: Build for Linux-x64
-      run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=linux-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'ubuntu-latest'
-    - name: Build for Linux-arm64
-      run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=linux-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
-      if: matrix.os == 'ubuntu-latest'
-        
-    - name: Unit Test Windows x64
-      env:
-         AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-      run: dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x64 /p:Configuration=Debug
-      if: matrix.os == 'windows-latest'
-    - name: Unit Test Linux x64
-      env:
-         AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-      run: dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-x64 /p:Configuration=Debug
-      if: matrix.os == 'ubuntu-latest'
-    - name: Unit Test macOS arm64
-      env:
-         AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-      # W/A for Dns.GetHostEntry(Dns.GetHostName()) exception https://github.com/actions/runner-images/issues/8649
-      run: |
-         echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts 
-         ./test/unit/macos_unblock_testip.sh
-         dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-arm64 /p:Configuration=Debug
-      if: matrix.os == 'macos-latest'
+      - name: Restore dependencies
+        run: dotnet restore
 
-    - uses: actions/upload-artifact@v4
-      with:
-        name: XBuild
-        path: artifacts/build/net8.0
-    
-    - uses: actions/upload-artifact@v4
-      with:
-        name: XBuild
-        path: artifacts/build/images
-      if: matrix.os == 'ubuntu-latest'
+      - name: Build Docker Image TAR file
+        run: |
+          mkdir -p artifacts/build/images 
+          DOCKER_BUILDKIT=1 docker build . --build-arg "REVISION=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}" --build-arg "VERSION=${{ env.MAJOR }}.${{ env.MINOR }}" -t azbridge:${{ env.MAJOR }}.${{ env.MINOR }} -t azbridge
+          docker save azbridge:${{ env.MAJOR }}.${{ env.MINOR }} > artifacts/build/images/azbridge-oci-image-${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}.tar
+        if: matrix.os == 'ubuntu-latest'
 
-    #- name: Integration Tests Docker/Linux
-    #  env:
-    #     AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-    #  run: bash ./verify-build.sh
-    #  if: matrix.os == 'ubuntu-latest'
-      
-    #- name: Integration Tests Windows
-    #  env:
-    #     AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
-    #  run: ./verify-build.cmd
-    #  if: matrix.os == 'windows-latest'
-      
-    # create a release if a tag has been pushed
-    - name: Generate Release
-      uses: ncipollo/release-action@v1
-      if: startsWith(github.ref, 'refs/tags/v')
-      with:
-        artifacts: "artifacts/build/net8.0/*,artifacts/build/images/*"
-        generateReleaseNotes: true
-        allowUpdates: true
-    
+      - name: Build for Windows-x64
+        run: dotnet msbuild /t:Package /p:WindowsOnly=true /p:RuntimeIdentifier=win-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'windows-latest'
+      - name: Build for Windows-arm64
+        run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'windows-latest'
+      - name: Build for Windows-x86
+        run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=win-x86 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'windows-latest'
+      - name: Build for macOS-x64
+        run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'macos-latest'
+      - name: Build for macOS-arm64
+        run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=osx-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'macos-latest'
+      - name: Build for Linux-x64
+        run: dotnet msbuild /t:Package /p:WindowsOnly=false /p:RuntimeIdentifier=linux-x64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'ubuntu-latest'
+      - name: Build for Linux-arm64
+        run: dotnet msbuild /t:Restore,Package /p:WindowsOnly=false /p:RuntimeIdentifier=linux-arm64 /p:Configuration=Release /p:TargetFramework=net8.0 /p:VersionSuffix=rel /p:VersionPrefix=${{ env.MAJOR }}.${{ env.MINOR }}.${{ env.PATCH }}
+        if: matrix.os == 'ubuntu-latest'
+
+      - name: Unit Test Windows x64
+        env:
+          AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
+        run: dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=win-x64 /p:Configuration=Debug
+        if: matrix.os == 'windows-latest'
+      - name: Unit Test Linux x64
+        env:
+          AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
+        run: dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=linux-x64 /p:Configuration=Debug
+        if: matrix.os == 'ubuntu-latest'
+      - name: Unit Test macOS arm64
+        env:
+          AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
+        # W/A for Dns.GetHostEntry(Dns.GetHostName()) exception https://github.com/actions/runner-images/issues/8649
+        run: |
+          echo -e "$(ipconfig getifaddr en0) $(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts 
+          ./test/unit/macos_unblock_testip.sh
+          dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-arm64 /p:Configuration=Debug
+        if: matrix.os == 'macos-latest'
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: XBuild-${{ matrix.os }}
+          path: artifacts/build/net8.0
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: XBuild-Docker-Images-ubuntu-latest
+          path: artifacts/build/images
+        if: matrix.os == 'ubuntu-latest'
+
+      #- name: Integration Tests Docker/Linux
+      #  env:
+      #     AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
+      #  run: bash ./verify-build.sh
+      #  if: matrix.os == 'ubuntu-latest'
+
+      #- name: Integration Tests Windows
+      #  env:
+      #     AZBRIDGE_TEST_CXNSTRING: ${{ secrets.AZBRIDGE_TEST_CXNSTRING }}
+      #  run: ./verify-build.cmd
+      #  if: matrix.os == 'windows-latest'
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: ./artifacts
+
+      - name: Generate Release
+        uses: ncipollo/release-action@v1
+        with:
+          artifacts: "artifacts/**/*"
+          generateReleaseNotes: true
+          allowUpdates: true

--- a/.github/workflows/main-ci-build.yml
+++ b/.github/workflows/main-ci-build.yml
@@ -91,12 +91,12 @@ jobs:
          dotnet test /p:TargetFramework=net8.0 /p:RuntimeIdentifier=osx-arm64 /p:Configuration=Debug
       if: matrix.os == 'macos-latest'
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: XBuild
         path: artifacts/build/net8.0
     
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: XBuild
         path: artifacts/build/images

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Azure.Relay" Version="3.0.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.12.0" />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2  " />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,7 +31,7 @@
     <PackageVersion Include="Microsoft.Azure.Relay" Version="3.0.1" />
     <PackageVersion Include="McMaster.Extensions.CommandLineUtils" Version="4.1.1" />
     <PackageVersion Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageVersion Include="Azure.Identity" Version="1.14.2  " />
+    <PackageVersion Include="Azure.Identity" Version="1.14.2" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Systemd" Version="8.0.0" />


### PR DESCRIPTION
### Summary
* Bump **Azure.Identity** to **1.14.2** .
* Bump **actions/upload-artifact** to **v4**
* Fix GitHub Actions workflow for automated releases

The Azure.Identity update addresses credential chain prioritization issues where Managed Identity was being prioritized over Azure CLI credentials in virtual desktop environments. This update enables proper use of the `AZURE_TOKEN_CREDENTIALS` environment variable to control credential chain behavior.

Reference: https://learn.microsoft.com/en-us/dotnet/azure/sdk/authentication/credential-chains?tabs=dac#exclude-a-credential-type-category

### Details
| Component | Old | New |
|-----------|-----|-----|
| Azure.Identity | 1.12.0 | 1.14.2 |
| actions/upload-artifact | v3 | v4 |
| Release process | Inline release step | Dedicated release job |
| Artifact naming | Conflicting names | OS-specific naming |

### GitHub Actions Improvements
* Separated release into dedicated job that runs after all builds complete
* Fixed artifact naming conflicts by using OS-specific names (XBuild-${{ matrix.os }})
* Updated to actions/upload-artifact@v4 for better reliability
* Improved artifact collection pattern (artifacts/**/*) for comprehensive releases

### Checklist
- [x] Builds locally (`dotnet build -c Release`)
- [x] Unit tests pass on Windows (with `xUnit.ParallelizeTestCollections=false`)
- [x] GitHub Actions workflow tested in forked repository
- [x] Release process verified with v0.15.1 tag
- [x] All platforms (Windows/Linux/macOS) build successfully
- [x] Docker image build tested
- [x] Signed Microsoft CLA